### PR TITLE
inital react, redux, redux devtools scaffold

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,20 @@
+{
+  "stage": 0,
+  "env": {
+    "development": {
+      "plugins": ["react-display-name", "react-transform"],
+      "extra": {
+        "react-transform": {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }, {
+            "transform": "react-transform-catch-errors",
+            "imports": ["react", "redbox-react"]
+          }]
+        }
+      }
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,218 @@
+// From https://github.com/airbnb/javascript/blob/master/linters/.eslintrc
+{
+  "parser": "babel-eslint",          // https://github.com/babel/babel-eslint
+  "plugins": [
+    "react"                          // https://github.com/yannickcr/eslint-plugin-react
+  ],
+  "env": {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
+    "browser": true,                 // browser global variables
+    "node": true                     // Node.js global variables and Node.js-specific rules
+  },
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "blockBindings": true,
+    "classes": true,
+    "defaultParams": true,
+    "destructuring": true,
+    "forOf": true,
+    "generators": false,
+    "modules": true,
+    "objectLiteralComputedProperties": true,
+    "objectLiteralDuplicateProperties": false,
+    "objectLiteralShorthandMethods": true,
+    "objectLiteralShorthandProperties": true,
+    "spread": true,
+    "superInFunctions": true,
+    "templateStrings": true,
+    "jsx": true
+  },
+  "rules": {
+/**
+ * Strict mode
+ */
+    // babel inserts "use strict"; for us
+    "strict": [2, "never"],          // http://eslint.org/docs/rules/strict
+
+/**
+ * ES6
+ */
+    "no-var": 2,                     // http://eslint.org/docs/rules/no-var
+    "prefer-const": 2,               // http://eslint.org/docs/rules/prefer-const
+
+/**
+ * Variables
+ */
+    "no-shadow": 2,                  // http://eslint.org/docs/rules/no-shadow
+    "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    "no-unused-vars": [2, {          // http://eslint.org/docs/rules/no-unused-vars
+      "vars": "local",
+      "args": "after-used"
+    }],
+    "no-use-before-define": 2,       // http://eslint.org/docs/rules/no-use-before-define
+
+/**
+ * Possible errors
+ */
+    "comma-dangle": [2, "always-multiline"],    // http://eslint.org/docs/rules/comma-dangle
+    "no-cond-assign": [2, "always"], // http://eslint.org/docs/rules/no-cond-assign
+    "no-console": 1,                 // http://eslint.org/docs/rules/no-console
+    "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger
+    "no-alert": 1,                   // http://eslint.org/docs/rules/no-alert
+    "no-constant-condition": 1,      // http://eslint.org/docs/rules/no-constant-condition
+    "no-dupe-keys": 2,               // http://eslint.org/docs/rules/no-dupe-keys
+    "no-duplicate-case": 2,          // http://eslint.org/docs/rules/no-duplicate-case
+    "no-empty": 2,                   // http://eslint.org/docs/rules/no-empty
+    "no-ex-assign": 2,               // http://eslint.org/docs/rules/no-ex-assign
+    "no-extra-boolean-cast": 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
+    "no-extra-semi": 2,              // http://eslint.org/docs/rules/no-extra-semi
+    "no-func-assign": 2,             // http://eslint.org/docs/rules/no-func-assign
+    "no-inner-declarations": 2,      // http://eslint.org/docs/rules/no-inner-declarations
+    "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
+    "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
+    "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
+    "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
+    "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
+    "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan
+    "block-scoped-var": 2,           // http://eslint.org/docs/rules/block-scoped-var
+    "quote-props": [2, "as-needed"], // http://eslint.org/docs/rules/quote-props
+
+/**
+ * Best practices
+ */
+    "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
+    "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
+    "default-case": 2,               // http://eslint.org/docs/rules/default-case
+    "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation
+      "allowKeywords": true
+    }],
+    "eqeqeq": 2,                     // http://eslint.org/docs/rules/eqeqeq
+    "guard-for-in": 2,               // http://eslint.org/docs/rules/guard-for-in
+    "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
+    "no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
+    "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
+    "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
+    "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
+    "no-extra-bind": 2,              // http://eslint.org/docs/rules/no-extra-bind
+    "no-fallthrough": 2,             // http://eslint.org/docs/rules/no-fallthrough
+    "no-floating-decimal": 2,        // http://eslint.org/docs/rules/no-floating-decimal
+    "no-implied-eval": 2,            // http://eslint.org/docs/rules/no-implied-eval
+    "no-lone-blocks": 2,             // http://eslint.org/docs/rules/no-lone-blocks
+    "no-loop-func": 2,               // http://eslint.org/docs/rules/no-loop-func
+    "no-multi-str": 2,               // http://eslint.org/docs/rules/no-multi-str
+    "no-native-reassign": 2,         // http://eslint.org/docs/rules/no-native-reassign
+    "no-new": 2,                     // http://eslint.org/docs/rules/no-new
+    "no-new-func": 2,                // http://eslint.org/docs/rules/no-new-func
+    "no-new-wrappers": 2,            // http://eslint.org/docs/rules/no-new-wrappers
+    "no-octal": 2,                   // http://eslint.org/docs/rules/no-octal
+    "no-octal-escape": 2,            // http://eslint.org/docs/rules/no-octal-escape
+    "no-param-reassign": 2,          // http://eslint.org/docs/rules/no-param-reassign
+    "no-proto": 2,                   // http://eslint.org/docs/rules/no-proto
+    "no-redeclare": 2,               // http://eslint.org/docs/rules/no-redeclare
+    "no-return-assign": 2,           // http://eslint.org/docs/rules/no-return-assign
+    "no-script-url": 2,              // http://eslint.org/docs/rules/no-script-url
+    "no-self-compare": 2,            // http://eslint.org/docs/rules/no-self-compare
+    "no-sequences": 2,               // http://eslint.org/docs/rules/no-sequences
+    "no-throw-literal": 2,           // http://eslint.org/docs/rules/no-throw-literal
+    "no-with": 2,                    // http://eslint.org/docs/rules/no-with
+    "radix": 2,                      // http://eslint.org/docs/rules/radix
+    "vars-on-top": 2,                // http://eslint.org/docs/rules/vars-on-top
+    "wrap-iife": [2, "any"],         // http://eslint.org/docs/rules/wrap-iife
+    "yoda": 2,                       // http://eslint.org/docs/rules/yoda
+
+/**
+ * Style
+ */
+    "indent": [2, 2],                // http://eslint.org/docs/rules/indent
+    "brace-style": [2,               // http://eslint.org/docs/rules/brace-style
+      "1tbs", {
+      "allowSingleLine": true
+    }],
+    "quotes": [
+      2, "single", "avoid-escape"    // http://eslint.org/docs/rules/quotes
+    ],
+    "camelcase": [2, {               // http://eslint.org/docs/rules/camelcase
+      "properties": "never"
+    }],
+    "comma-spacing": [2, {           // http://eslint.org/docs/rules/comma-spacing
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "last"],      // http://eslint.org/docs/rules/comma-style
+    "eol-last": 2,                   // http://eslint.org/docs/rules/eol-last
+    "func-names": 1,                 // http://eslint.org/docs/rules/func-names
+    "key-spacing": [2, {             // http://eslint.org/docs/rules/key-spacing
+        "beforeColon": false,
+        "afterColon": true
+    }],
+    "new-cap": [2, {                 // http://eslint.org/docs/rules/new-cap
+      "newIsCap": true
+    }],
+    "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+      "max": 2
+    }],
+    "no-nested-ternary": 2,          // http://eslint.org/docs/rules/no-nested-ternary
+    "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
+    "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
+    "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
+    "no-extra-parens": [2, "functions"], // http://eslint.org/docs/rules/no-extra-parens
+    "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
+    "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
+    "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
+    "semi": [2, "always"],           // http://eslint.org/docs/rules/semi
+    "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
+      "before": false,
+      "after": true
+    }],
+    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
+    "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
+    "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
+    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
+    "spaced-comment": 2,             // http://eslint.org/docs/rules/spaced-comment
+
+/**
+ * JSX style
+ */
+    "react/display-name": 0,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
+    "react/jsx-boolean-value": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
+    "react/jsx-quotes": [2, "double"], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md
+    "react/jsx-no-undef": 2,         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
+    "react/jsx-sort-props": 0,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
+    "react/jsx-sort-prop-types": 0,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
+    "react/jsx-uses-react": 2,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
+    "react/jsx-uses-vars": 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
+    "react/no-did-mount-set-state": [2, "allow-in-func"], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
+    "react/no-did-update-set-state": 2, // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
+    "react/no-multi-comp": 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
+    "react/no-unknown-property": 2,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
+    "react/prop-types": 2,           // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
+    "react/react-in-jsx-scope": 2,   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
+    "react/self-closing-comp": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+    "react/wrap-multilines": 2,      // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
+    "react/sort-comp": [2, {         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
+      "order": [
+        "displayName",
+        "propTypes",
+        "contextTypes",
+        "childContextTypes",
+        "mixins",
+        "statics",
+        "defaultProps",
+        "getDefaultProps",
+        "getInitialState",
+        "getChildContext",
+        "componentWillMount",
+        "componentDidMount",
+        "componentWillReceiveProps",
+        "shouldComponentUpdate",
+        "componentWillUpdate",
+        "componentDidUpdate",
+        "componentWillUnmount",
+        "/^on.+$/",
+        "/^get.+$/",
+        "/^render.+$/",
+        "render"
+      ]
+    }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+dist/**
+node_modules/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# jaws-dashboard
-A temporary repo for collaborating on a new dashboard for JAWS
+
+# jaws-dashboard (jaws-dashboard)
+
+React and Redux based Dashboard for JAWS
+
+## Running the project
+
+The generated project includes a development server on port `3000`, which will rebuild the app whenever you change application code. To start the server (with the dev-tools enabled), run:
+
+```bash
+$ npm start
+```
+
+To run the server with the dev-tools disabled, run:
+
+```bash
+$ DEBUG=false npm start
+```
+
+To build for production, this command will output optimized production code:
+
+```bash
+$ npm run build
+```

--- a/css/app.css
+++ b/css/app.css
@@ -1,0 +1,5 @@
+.text {
+  font-size: 2rem;
+  line-height: 1.5;
+  color: #FF0000;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JAWS Dashboard</title>
+  <link href="./static/app.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+
+  <div id="main"></div>
+
+  <script src="./static/bundle.js"></script>
+</body>
+</html>

--- a/js/actions/HomeActions.js
+++ b/js/actions/HomeActions.js
@@ -1,0 +1,8 @@
+import {TITLE_CHANGED} from '../constants/ActionTypes';
+
+export function changeTitle(text) {
+  return {
+    type: TITLE_CHANGED,
+    text
+  }
+}

--- a/js/components/Home.js
+++ b/js/components/Home.js
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import * as HomeActions from '../actions/HomeActions';
+import styles from '../../css/app.css';
+
+class Home extends Component {
+  render() {
+    const {title, dispatch} = this.props;
+    const actions = bindActionCreators(HomeActions, dispatch);
+    return (
+      <main>
+        <h1 className={styles.text}>Welcome {title}!</h1>
+        <button onClick={e => actions.changeTitle(prompt())}>
+          Update Title
+        </button>
+      </main>
+    );
+  }
+}
+
+export default connect(state => state.Sample)(Home)

--- a/js/constants/ActionTypes.js
+++ b/js/constants/ActionTypes.js
@@ -1,0 +1,4 @@
+export const DATA_FETCHED = 'DATA_FETCHED';
+export const DATA_SUCCEEDED = 'DATA_SUCCEEDED';
+export const DATA_FAILED = 'DATA_FAILED';
+export const TITLE_CHANGED = 'TITLE_CHANGED';

--- a/js/containers/App.js
+++ b/js/containers/App.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import configureStore from '../store/configureStore';
+import Home from '../components/Home';
+import {renderDevTools} from '../utils/devTools';
+
+const store = configureStore();
+
+export default React.createClass({
+  render() {
+    return (
+      <div>
+
+        {/* <Home /> is your app entry point */}
+        <Provider store={store}>
+          <Home />
+        </Provider>
+
+        {/* only renders when running in DEV mode */
+          renderDevTools(store)
+        }
+      </div>
+    );
+  }
+});

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './containers/App';
+
+ReactDOM.render(<App />, document.getElementById('main'));

--- a/js/reducers/Sample.js
+++ b/js/reducers/Sample.js
@@ -1,0 +1,14 @@
+import * as ActionTypes from '../constants/ActionTypes';
+
+let defaultState = {
+  title: 'Home'
+};
+
+export default function(state = defaultState, action) {
+  switch (action.type) {
+    case ActionTypes.TITLE_CHANGED:
+      return {...state, title: action.text};
+    default:
+      return state;
+  }
+}

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -1,0 +1,1 @@
+export {default as Sample} from './Sample';

--- a/js/store/configureStore.js
+++ b/js/store/configureStore.js
@@ -1,0 +1,23 @@
+import {createStore, applyMiddleware, combineReducers, compose} from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import {devTools, persistState} from 'redux-devtools';
+import * as reducers from '../reducers/index';
+
+let createStoreWithMiddleware;
+
+// Configure the dev tools when in DEV mode
+if (__DEV__) {
+  createStoreWithMiddleware = compose(
+    applyMiddleware(thunkMiddleware),
+    devTools(),
+    persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
+  )(createStore);
+} else {
+  createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore);
+}
+
+const rootReducer = combineReducers(reducers);
+
+export default function configureStore(initialState) {
+  return createStoreWithMiddleware(rootReducer, initialState);
+}

--- a/js/utils/devTools.js
+++ b/js/utils/devTools.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export function renderDevTools(store) {
+  if (__DEV__) {
+    let {DevTools, DebugPanel, LogMonitor} = require('redux-devtools/lib/react');
+    return (
+      <DebugPanel top right bottom>
+        <DevTools store={store} monitor={LogMonitor} visibleOnLoad={false} />
+      </DebugPanel>
+    );
+  }
+
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "jaws-dashboard",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "DEBUG=true node server.js",
+    "build": "webpack -p --config webpack.production.js",
+    "build-dev": "webpack -p"
+  },
+  "dependencies": {
+    "babel-core": "^5.0.0",
+    "es6-promise": "^3.0.2",
+    "lodash": "^3.10.1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "redux": "^3.0.4",
+    "react-redux": "^4.0.0",
+    "redux-devtools": "^2.1.5",
+    "redux-thunk": "^1.0.0",
+    "whatwg-fetch": "^0.10.1"
+  },
+  "devDependencies": {
+    "babel-core": "^5.0.0",
+    "babel-loader": "^5.0.0",
+    "babel-plugin-react-display-name": "^2.0.0",
+    "babel-plugin-react-transform": "^1.1.1",
+    "css-loader": "^0.22.0",
+    "cssnext-loader": "^1.0.1",
+    "express": "^4.13.3",
+    "extract-text-webpack-plugin": "^0.9.1",
+    "path": "^0.12.7",
+    "react-transform-catch-errors": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
+    "redbox-react": "^1.1.1",
+    "style-loader": "^0.13.0",
+    "webpack": "^1.12.4",
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-hot-middleware": "^2.5.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+var path = require('path');
+var webpack = require('webpack');
+var express = require('express');
+var config = require('./webpack.config');
+
+var app = express();
+var compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  noInfo: true,
+  publicPath: config.output.publicPath,
+  historyApiFallback: true
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', function(req, res) {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+  
+app.listen(3000, 'localhost', function (err, result) {
+  if (err) {
+    console.log(err);
+  }
+
+  console.log('Listening at localhost:3000');
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var devFlagPlugin = new webpack.DefinePlugin({
+  __DEV__: JSON.stringify(JSON.parse(process.env.DEBUG || 'false'))
+});
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000',
+    './js/index.js'
+  ],
+  output: {
+    path: __dirname + '/static/',
+    publicPath: '/static/',
+    filename: 'bundle.js',
+    hot: true
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin(),
+    devFlagPlugin,
+    new ExtractTextPlugin('app.css')
+  ],
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel'], exclude: /node_modules/ },
+      { test: /\.css$/, loader: ExtractTextPlugin.extract('css-loader?module!cssnext-loader') }
+    ]
+  },
+  resolve: {
+    extensions: ['', '.js', '.json']
+  }
+};

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,0 +1,31 @@
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var devFlagPlugin = new webpack.DefinePlugin({
+  __DEV__: JSON.stringify(JSON.parse(process.env.DEBUG || 'false'))
+});
+
+module.exports = {
+  entry: [
+    './js/index.js'
+  ],
+  output: {
+    path: __dirname + '/static/',
+    publicPath: '/static/',
+    filename: 'bundle.js',
+  },
+  plugins: [
+    new webpack.NoErrorsPlugin(),
+    devFlagPlugin,
+    new ExtractTextPlugin('app.css')
+  ],
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel'], exclude: /node_modules/ },
+      { test: /\.css$/, loader: ExtractTextPlugin.extract('css-loader?module!cssnext-loader') }
+    ]
+  },
+  resolve: {
+    extensions: ['', '.js', '.json']
+  }
+};


### PR DESCRIPTION
TODO: replace express with koa as requested

@ac360 Apologies for the delay, but here's the initial scaffold for the React/Redux base for the Dashboard.  This satisfies the base for https://github.com/jaws-framework/JAWS/issues/240

It is based on my customize version of the generator-redux scaffolding - https://github.com/kevinold/generator-redux/tree/replace-react-hot-loader

I am not familiar with Koa, but switching over to it from express should be trivial for those familiar with it.  Right now server.js is a single route.